### PR TITLE
chore: update .env.sample and main.go for keep-alive mechanism. Disabled gocoroutine functions instead add cronjob for keep-alive get-req.

### DIFF
--- a/splitbill-llmocr-api/.env.sample
+++ b/splitbill-llmocr-api/.env.sample
@@ -27,4 +27,7 @@ CORS_ALLOWED_ORIGINS=http://localhost:3001  # Your Next.js frontend URL
 LOG_LEVEL=debug  # debug, info, warn, error
 
 # n8n Webhook URL
-N8N_WEBHOOK_URL = https://n8n-dev.example.com/0000
+N8N_WEBHOOK_URL=https://n8n-dev.example.com/0000
+
+# Render External URl
+RENDER_EXTERNAL_URL=https://app-api.com

--- a/splitbill-llmocr-web/package.json
+++ b/splitbill-llmocr-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "splitbill-llmocr-web",
-  "version": "0.1.0",
+  "version": "0.2.1",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",

--- a/splitbill-llmocr-web/package.json
+++ b/splitbill-llmocr-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "splitbill-llmocr-web",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",


### PR DESCRIPTION
- Added RENDER_EXTERNAL_URL to .env.sample for external URL configuration.
- Commented out the keep-alive function in main.go, preserving it for future use.
- Updated pingHealthEndpoint to use external URL for health checks, enhancing flexibility for different deployment environments.
- made a cronjob for keep-alive get request.